### PR TITLE
Bugfix/magento 2.3.3 compatibility

### DIFF
--- a/Model/Emailcatcher.php
+++ b/Model/Emailcatcher.php
@@ -1,7 +1,7 @@
 <?php
 /**
  * A Magento 2 module named Experius/EmailCatcher
- * Copyright (C) 2016 Derrick Heesbeen
+ * Copyright (C) 2019 Experius
  *
  * This file included in Experius/EmailCatcher is licensed under OSL 3.0
  *
@@ -13,23 +13,42 @@ namespace Experius\EmailCatcher\Model;
 
 class Emailcatcher extends \Magento\Framework\Model\AbstractModel
 {
+    /**
+     * @var string
+     */
     protected $_eventPrefix = 'experius_email_catcher';
 
+    /**
+     * @var string
+     */
     protected $_eventObject = 'email';
 
+    /**
+     * @var \Magento\Framework\App\ProductMetadataInterface|null
+     */
     protected $magentoProductMetaData;
 
+    /**
+     * Emailcatcher constructor.
+     *
+     * @param \Magento\Framework\Model\Context $context
+     * @param \Magento\Framework\Registry $registry
+     * @param \Magento\Framework\App\ProductMetadataInterface $magentoProductMetaData
+     * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
+     * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param array $data
+     */
     public function __construct(
         \Magento\Framework\Model\Context $context,
         \Magento\Framework\Registry $registry,
+        \Magento\Framework\App\ProductMetadataInterface $magentoProductMetaData,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
-        \Magento\Framework\App\ProductMetadataInterface $magentoProductMetaData,
         array $data = []
     ) {
-        $this->magentoProductMetaData = $magentoProductMetaData;
-
         parent::__construct($context, $registry, $resource, $resourceCollection, $data);
+
+        $this->magentoProductMetaData = $magentoProductMetaData;
     }
 
     protected function _construct()
@@ -37,9 +56,14 @@ class Emailcatcher extends \Magento\Framework\Model\AbstractModel
         $this->_init('Experius\EmailCatcher\Model\ResourceModel\Emailcatcher');
     }
 
+    /**
+     * Save message
+     *
+     * @param $message
+     */
     public function saveMessage($message)
     {
-        $bodyObject  = $message->getBody();
+        $bodyObject = $message->getBody();
 
         if (!method_exists($bodyObject, 'getRawContent') && method_exists($message, 'getRawMessage')) {
             $zendMessageObject = new \Zend\Mail\Message();
@@ -69,6 +93,13 @@ class Emailcatcher extends \Magento\Framework\Model\AbstractModel
         $this->save();
     }
 
+    /**
+     * Get email addresses from address object
+     *
+     * @param $addresses
+     * @param bool $asString
+     * @return array|string
+     */
     public function getEmailAddressesFromObject($addresses, $asString = true)
     {
         $emailAddresses = [];
@@ -82,5 +113,4 @@ class Emailcatcher extends \Magento\Framework\Model\AbstractModel
 
         return $emailAddresses;
     }
-
 }

--- a/view/adminhtml/ui_component/experius_emailcatcher_index.xml
+++ b/view/adminhtml/ui_component/experius_emailcatcher_index.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0" ?>
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-	<argument name="context" xsi:type="configurableObject">
-		<argument name="class" xsi:type="string">Magento\Framework\View\Element\UiComponent\Context</argument>
-		<argument name="namespace" xsi:type="string">experius_emailcatcher_index</argument>
-	</argument>
 	<argument name="data" xsi:type="array">
 		<item name="js_config" xsi:type="array">
 			<item name="provider" xsi:type="string">experius_emailcatcher_index.experius_emailcatcher_grid_data_source</item>
@@ -15,7 +11,6 @@
 				<item name="name" xsi:type="string">cleanup</item>
 				<item name="label" translate="true" xsi:type="string">Run Cleanup</item>
 				<item name="url" xsi:type="string">*/*/cleanup</item>
-				<!--<item name="on_click" xsi:type="string">deleteConfirm('Are you sure you want to do this?')</item>-->
 			</item>
 		</item>
 	</argument>
@@ -45,26 +40,6 @@
 		<bookmark name="bookmarks"/>
 		<columnsControls name="columns_controls"/>
 		<filters name="listing_filters"/>
-		<massaction name="listing_massaction" component="Magento_Ui/js/grid/tree-massactions">
-			<!--<action name="forward">-->
-				<!--<settings>-->
-					<!--<url path="*/*/forward"/>-->
-					<!--<type>forward</type>-->
-					<!--<label translate="true">Forward</label>-->
-				<!--</settings>-->
-			<!--</action>-->
-			<!--<action name="delete">-->
-				<!--<settings>-->
-					<!--<confirm>-->
-						<!--<message translate="true">Delete selected items?</message>-->
-						<!--<title translate="true">Delete items</title>-->
-					<!--</confirm>-->
-					<!--<url path="*/*/massDelete"/>-->
-					<!--<type>delete</type>-->
-					<!--<label translate="true">Delete</label>-->
-				<!--</settings>-->
-			<!--</action>-->
-		</massaction>
 		<paging name="listing_paging"/>
 	</listingToolbar>
 	<columns name="experius_emailcatcher_columns">
@@ -82,13 +57,6 @@
 				</item>
 			</item>
 		</argument>
-		<selectionsColumn name="ids">
-			<argument name="data" xsi:type="array">
-				<item name="config" xsi:type="array">
-					<item name="indexField" xsi:type="string">emailcatcher_id</item>
-				</item>
-			</argument>
-		</selectionsColumn>
 		<column name="emailcatcher_id">
 			<argument name="data" xsi:type="array">
 				<item name="config" xsi:type="array">
@@ -98,11 +66,11 @@
 				</item>
 			</argument>
 		</column>
-		<column name="recipient">
+		<column name="subject">
 			<argument name="data" xsi:type="array">
 				<item name="config" xsi:type="array">
 					<item name="filter" xsi:type="string">text</item>
-					<item name="label" translate="true" xsi:type="string">To</item>
+					<item name="label" translate="true" xsi:type="string">Subject</item>
 				</item>
 			</argument>
 		</column>
@@ -114,11 +82,11 @@
 				</item>
 			</argument>
 		</column>
-		<column name="subject">
+		<column name="recipient">
 			<argument name="data" xsi:type="array">
 				<item name="config" xsi:type="array">
 					<item name="filter" xsi:type="string">text</item>
-					<item name="label" translate="true" xsi:type="string">Subject</item>
+					<item name="label" translate="true" xsi:type="string">To</item>
 				</item>
 			</argument>
 		</column>


### PR DESCRIPTION
 [BUGFIX] __construct() dependency injection breaks on Emailcatcher model due to sort order of injected classes.
 [BUGFIX] UI xml argument: name="context" xsi:type="configurableObject" breaks adminhtml in Magento 2.3.3.
[FEATURE] Removed redundant commented out xml in UI xml declaration for mass action.
[FEATURE] Sort order changed to be a tad more logical in the adminhtml overview.
[FEATURE] Removed "id" selection column, since no actions are present.

Fix for the 2.3.3 "forward" and "send" is in the making.