### PR TITLE
[BUGFIX] - Fixes Reset Password not working due to zend changes

### DIFF
--- a/Model/Emailcatcher.php
+++ b/Model/Emailcatcher.php
@@ -76,14 +76,12 @@ class Emailcatcher extends \Magento\Framework\Model\AbstractModel
         $bodyObject = $message->getBody();
 
         if (!method_exists($bodyObject, 'getRawContent') && method_exists($message, 'getRawMessage')) {
-            $zendMessageObject = new \Zend\Mail\Message();
-            $zendMessage = $zendMessageObject::fromString($message->getRawMessage());
-            $body = $zendMessage->getBodyText();
+            $body = $message->getBodyText();
             if (version_compare($this->magentoProductMetaData->getVersion(), "2.3.3", ">=")) {
                 $body = quoted_printable_decode($body);
             }
-            $recipient = $this->getEmailAddressesFromObject($zendMessage->getTo());
-            $sender = $this->getEmailAddressesFromObject($zendMessage->getFrom());
+            $recipient = $this->getEmailAddressesFromObject($message->getTo());
+            $sender = $this->getEmailAddressesFromObject($message->getFrom());
         } elseif (method_exists($bodyObject, 'getRawContent')) {
             $body = $bodyObject->getRawContent();
             $recipient = implode(',', $message->getRecipients());


### PR DESCRIPTION
The error message was this:

Exception message: Invalid header value detected
Trace: <pre>#1 Zend\Mail\Header\AbstractAddressList->getFieldValue() called at [vendor/zendframework/zend-mail/src/Header/AbstractAddressList.php:209]
#2 Zend\Mail\Header\AbstractAddressList->toString() called at [vendor/zendframework/zend-mail/src/Headers.php:426]
#3 Zend\Mail\Headers->toString() called at [vendor/zendframework/zend-mail/src/Message.php:546]
#4 Zend\Mail\Message->toString() called at [vendor/magento/framework/Mail/EmailMessage.php:217]
#5 Magento\Framework\Mail\EmailMessage->toString() called at [vendor/magento/framework/Mail/EmailMessage.php:209]
#6 Magento\Framework\Mail\EmailMessage->getRawMessage() called at [vendor/experius/module-emailcatcher/Model/Emailcatcher.php:80]