### PR TITLE
Feature - Full 2.2.X compatibility

### DIFF
--- a/Setup/InstallSchema.php
+++ b/Setup/InstallSchema.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * A Magento 2 module named Experius/EmailCatcher
+ * Copyright (C) 2019 Experius
+ *
+ * This file included in Experius/EmailCatcher is licensed under OSL 3.0
+ *
+ * http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * Please see LICENSE.txt for the full text of the OSL 3.0 license
+ */
+
+namespace Experius\EmailCatcher\Setup;
+
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+use Magento\Framework\Setup\InstallSchemaInterface;
+
+class InstallSchema implements InstallSchemaInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function install(
+        SchemaSetupInterface $setup,
+        ModuleContextInterface $context
+    ) {
+        $installer = $setup;
+        $installer->startSetup();
+        $table_experius_emailcatcher = $setup->getConnection()->newTable($setup->getTable('experius_emailcatcher'));
+        $table_experius_emailcatcher->addColumn(
+            'emailcatcher_id',
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+            null,
+            ['identity' => true, 'nullable' => false, 'primary' => true, 'unsigned' => true,],
+            'Entity ID'
+        );
+        $table_experius_emailcatcher->addColumn(
+            'to',
+            \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+            null,
+            [],
+            'To Email Address'
+        );
+        $table_experius_emailcatcher->addColumn(
+            'from',
+            \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+            null,
+            [],
+            'From Email Address'
+        );
+        $table_experius_emailcatcher->addColumn(
+            'subject',
+            \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+            null,
+            [],
+            'Subject'
+        );
+        $table_experius_emailcatcher->addColumn(
+            'body',
+            \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+            null,
+            [],
+            'Email Body'
+        );
+        $table_experius_emailcatcher->addColumn(
+            'created_at',
+            \Magento\Framework\DB\Ddl\Table::TYPE_DATETIME,
+            null,
+            [],
+            'Created At'
+        );
+        $table_experius_emailcatcher->addColumn(
+            'store_id',
+            \Magento\Framework\DB\Ddl\Table::TYPE_INTEGER,
+            null,
+            [],
+            'Store Id'
+        );
+        $setup->getConnection()->createTable($table_experius_emailcatcher);
+        $setup->endSetup();
+    }
+}

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -40,5 +40,19 @@ class UpgradeSchema implements UpgradeSchemaInterface
                 );
             }
         }
+        if (version_compare($context->getVersion(), "1.0.2", "<")) {
+            $connection = $setup->getConnection();
+            if (!$connection->tableColumnExists($setup->getTable('experius_emailcatcher'), 'template_identifier')) {
+                $connection->addColumn(
+                    $setup->getTable('experius_emailcatcher'),
+                    'template_identifier',
+                    [
+                        'type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT,
+                        'nullable' => true,
+                        'comment' => 'Email Template Identifier'
+                    ]
+                );
+            }
+        }
     }
 }

--- a/Setup/UpgradeSchema.php
+++ b/Setup/UpgradeSchema.php
@@ -1,0 +1,44 @@
+<?php
+/**
+ * A Magento 2 module named Experius/EmailCatcher
+ * Copyright (C) 2019 Experius
+ *
+ * This file included in Experius/EmailCatcher is licensed under OSL 3.0
+ *
+ * http://opensource.org/licenses/osl-3.0.php  Open Software License (OSL 3.0)
+ * Please see LICENSE.txt for the full text of the OSL 3.0 license
+ */
+namespace Experius\EmailCatcher\Setup;
+use Magento\Framework\Setup\UpgradeSchemaInterface;
+use Magento\Framework\Setup\ModuleContextInterface;
+use Magento\Framework\Setup\SchemaSetupInterface;
+class UpgradeSchema implements UpgradeSchemaInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function upgrade(
+        SchemaSetupInterface $setup,
+        ModuleContextInterface $context
+    ) {
+        if (version_compare($context->getVersion(), "1.0.1", "<")) {
+            $connection = $setup->getConnection();
+            if (!$connection->tableColumnExists($setup->getTable('experius_emailcatcher'), 'recipient')) {
+                $connection->changeColumn(
+                    $setup->getTable('experius_emailcatcher'),
+                    'to',
+                    'recipient',
+                    ['type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT]
+                );
+            }
+            if (!$connection->tableColumnExists($setup->getTable('experius_emailcatcher'), 'sender')) {
+                $connection->changeColumn(
+                    $setup->getTable('experius_emailcatcher'),
+                    'from',
+                    'sender',
+                    ['type' => \Magento\Framework\DB\Ddl\Table::TYPE_TEXT]
+                );
+            }
+        }
+    }
+}

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" ?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-	<module name="Experius_EmailCatcher" setup_version="1.0.1" schema_version="1.0.1">
+	<module name="Experius_EmailCatcher" setup_version="1.0.2" schema_version="1.0.2">
 		<sequence>
 			<module name="Magento_Email"/>
 		</sequence>


### PR DESCRIPTION
Tested on 2.2.11, this re-adds the installscripts so the module can be installed on a "new" 2.2 shop. Added any changes to the db_schema after the removal of the scripts as well, so no functionality is lost. Together with the other commits today by @rubenexp , this gives the module full 2.2 backwards compatibility.